### PR TITLE
Fail fast if rustfmt fails.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,9 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - name: Cancel workflow
+        if: failure()
+        uses: andymckay/cancel-action@0.2
 
   security:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This applies IronCoreLabs/recrypt-rs#121.