### PR TITLE
Fix release workflow for Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
-name: ironoxide-cli
+name: CI
 
-on: push
+on:
+  push:
+    branches: master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: release-${{ matrix.os }}
-          path: target/release/ironoxide-cli-${{ matrix.os }}
+          path: target/release/ironoxide-cli-${{ matrix.os }}${{ matrix.ext }}
   # release:
   #   runs-on: ubuntu-18.04
   #   needs: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,16 @@ on:
   push:
     tags:
       - "*"
+    branches: release-test
 
 jobs:
   build:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
+        include:
+          - os: windows-2019
+            ext: .exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -17,113 +21,112 @@ jobs:
         run: cargo build --release
       - name: Package release artifacts
         working-directory: target/release
-        run: mv ironoxide-cli ironoxide-cli-${{ matrix.os }}
+        run: mv ironoxide-cli${{ matrix.ext }} ironoxide-cli-${{ matrix.os }}${{ matrix.ext }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
           name: release-${{ matrix.os }}
           path: target/release/ironoxide-cli-${{ matrix.os }}
-
-  release:
-    runs-on: ubuntu-18.04
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - name: Decrypt PGP key
-        uses: IronCoreLabs/ironhide-actions/decrypt@v1
-        with:
-          keys: ${{ secrets.IRONHIDE_KEYS }}
-          input: .github/signing-key.asc.iron
-      - name: Import PGP key
-        run: gpg --batch --import .github/signing-key.asc
-      - uses: actions/create-release@v1
-        id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Version ${{ github.ref }}
-
-      - name: Download release artifacts from ubuntu-18.04
-        uses: actions/download-artifact@v1
-        with:
-          name: release-ubuntu-18.04
-          path: release/ubuntu-18.04
-      - name: Sign artifact for ubuntu-18.04
-        run: |
-          gpg --batch --detach-sign -a release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-          gpg --batch --verify release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-      - name: Upload artifact for ubuntu-18.04
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-          asset_name: ironoxide-cli-ubuntu-18.04
-          asset_content_type: application/data
-      - name: Upload signature for ubuntu-18.04
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc
-          asset_name: ironoxide-cli-ubuntu-18.04.asc
-          asset_content_type: application/pgp-signature
-
-      - name: Download release artifacts from macos-10.15
-        uses: actions/download-artifact@v1
-        with:
-          name: release-macos-10.15
-          path: release/macos-10.15
-      - name: Sign artifact for macos-10.15
-        run: |
-          gpg --batch --detach-sign -a release/macos-10.15/ironoxide-cli-macos-10.15
-          gpg --batch --verify release/macos-10.15/ironoxide-cli-macos-10.15.asc release/macos-10.15/ironoxide-cli-macos-10.15
-      - name: Upload artifact for macos-10.15
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/macos-10.15/ironoxide-cli-macos-10.15
-          asset_name: ironoxide-cli-macos-10.15
-          asset_content_type: application/data
-      - name: Upload signature for macos-10.15
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/macos-10.15/ironoxide-cli-macos-10.15.asc
-          asset_name: ironoxide-cli-macos-10.15.asc
-          asset_content_type: application/pgp-signature
-
-      - name: Download release artifacts from windows-2019
-        uses: actions/download-artifact@v1
-        with:
-          name: release-windows-2019
-          path: release/windows-2019
-      - name: Sign artifact for windows-2019
-        run: |
-          gpg --batch --detach-sign -a release/windows-2019/ironoxide-cli-windows-2019	
-          gpg --batch --verify release/windows-2019/ironoxide-cli-windows-2019.asc release/windows-2019/ironoxide-cli-windows-2019
-      - name: Upload artifact for windows-2019
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/windows-2019/ironoxide-cli-windows-2019
-          asset_name: ironoxide-cli-windows-2019
-          asset_content_type: application/data
-      - name: Upload signature for windows-2019
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/windows-2019/ironoxide-cli-windows-2019.asc
-          asset_name: ironoxide-cli-windows-2019.asc
-          asset_content_type: application/pgp-signature
+  # release:
+  #   runs-on: ubuntu-18.04
+  #   needs: build
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Decrypt PGP key
+  #       uses: IronCoreLabs/ironhide-actions/decrypt@v1
+  #       with:
+  #         keys: ${{ secrets.IRONHIDE_KEYS }}
+  #         input: .github/signing-key.asc.iron
+  #     - name: Import PGP key
+  #       run: gpg --batch --import .github/signing-key.asc
+  #     - uses: actions/create-release@v1
+  #       id: release
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ github.ref }}
+  #         release_name: Version ${{ github.ref }}
+  #
+  #     - name: Download release artifacts from ubuntu-18.04
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: release-ubuntu-18.04
+  #         path: release/ubuntu-18.04
+  #     - name: Sign artifact for ubuntu-18.04
+  #       run: |
+  #         gpg --batch --detach-sign -a release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+  #         gpg --batch --verify release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+  #     - name: Upload artifact for ubuntu-18.04
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+  #         asset_name: ironoxide-cli-ubuntu-18.04
+  #         asset_content_type: application/data
+  #     - name: Upload signature for ubuntu-18.04
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc
+  #         asset_name: ironoxide-cli-ubuntu-18.04.asc
+  #         asset_content_type: application/pgp-signature
+  #
+  #     - name: Download release artifacts from macos-10.15
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: release-macos-10.15
+  #         path: release/macos-10.15
+  #     - name: Sign artifact for macos-10.15
+  #       run: |
+  #         gpg --batch --detach-sign -a release/macos-10.15/ironoxide-cli-macos-10.15
+  #         gpg --batch --verify release/macos-10.15/ironoxide-cli-macos-10.15.asc release/macos-10.15/ironoxide-cli-macos-10.15
+  #     - name: Upload artifact for macos-10.15
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/macos-10.15/ironoxide-cli-macos-10.15
+  #         asset_name: ironoxide-cli-macos-10.15
+  #         asset_content_type: application/data
+  #     - name: Upload signature for macos-10.15
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/macos-10.15/ironoxide-cli-macos-10.15.asc
+  #         asset_name: ironoxide-cli-macos-10.15.asc
+  #         asset_content_type: application/pgp-signature
+  #
+  #     - name: Download release artifacts from windows-2019
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: release-windows-2019
+  #         path: release/windows-2019
+  #     - name: Sign artifact for windows-2019
+  #       run: |
+  #         gpg --batch --detach-sign -a release/windows-2019/ironoxide-cli-windows-2019
+  #         gpg --batch --verify release/windows-2019/ironoxide-cli-windows-2019.asc release/windows-2019/ironoxide-cli-windows-2019
+  #     - name: Upload artifact for windows-2019
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/windows-2019/ironoxide-cli-windows-2019
+  #         asset_name: ironoxide-cli-windows-2019
+  #         asset_content_type: application/data
+  #     - name: Upload signature for windows-2019
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.release.outputs.upload_url }}
+  #         asset_path: release/windows-2019/ironoxide-cli-windows-2019.asc
+  #         asset_name: ironoxide-cli-windows-2019.asc
+  #         asset_content_type: application/pgp-signature

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches: release-test
 
 jobs:
   build:
@@ -27,106 +26,107 @@ jobs:
         with:
           name: release-${{ matrix.os }}
           path: target/release/ironoxide-cli-${{ matrix.os }}${{ matrix.ext }}
-  # release:
-  #   runs-on: ubuntu-18.04
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Decrypt PGP key
-  #       uses: IronCoreLabs/ironhide-actions/decrypt@v1
-  #       with:
-  #         keys: ${{ secrets.IRONHIDE_KEYS }}
-  #         input: .github/signing-key.asc.iron
-  #     - name: Import PGP key
-  #       run: gpg --batch --import .github/signing-key.asc
-  #     - uses: actions/create-release@v1
-  #       id: release
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tag_name: ${{ github.ref }}
-  #         release_name: Version ${{ github.ref }}
-  #
-  #     - name: Download release artifacts from ubuntu-18.04
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: release-ubuntu-18.04
-  #         path: release/ubuntu-18.04
-  #     - name: Sign artifact for ubuntu-18.04
-  #       run: |
-  #         gpg --batch --detach-sign -a release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-  #         gpg --batch --verify release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-  #     - name: Upload artifact for ubuntu-18.04
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
-  #         asset_name: ironoxide-cli-ubuntu-18.04
-  #         asset_content_type: application/data
-  #     - name: Upload signature for ubuntu-18.04
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc
-  #         asset_name: ironoxide-cli-ubuntu-18.04.asc
-  #         asset_content_type: application/pgp-signature
-  #
-  #     - name: Download release artifacts from macos-10.15
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: release-macos-10.15
-  #         path: release/macos-10.15
-  #     - name: Sign artifact for macos-10.15
-  #       run: |
-  #         gpg --batch --detach-sign -a release/macos-10.15/ironoxide-cli-macos-10.15
-  #         gpg --batch --verify release/macos-10.15/ironoxide-cli-macos-10.15.asc release/macos-10.15/ironoxide-cli-macos-10.15
-  #     - name: Upload artifact for macos-10.15
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/macos-10.15/ironoxide-cli-macos-10.15
-  #         asset_name: ironoxide-cli-macos-10.15
-  #         asset_content_type: application/data
-  #     - name: Upload signature for macos-10.15
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/macos-10.15/ironoxide-cli-macos-10.15.asc
-  #         asset_name: ironoxide-cli-macos-10.15.asc
-  #         asset_content_type: application/pgp-signature
-  #
-  #     - name: Download release artifacts from windows-2019
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: release-windows-2019
-  #         path: release/windows-2019
-  #     - name: Sign artifact for windows-2019
-  #       run: |
-  #         gpg --batch --detach-sign -a release/windows-2019/ironoxide-cli-windows-2019
-  #         gpg --batch --verify release/windows-2019/ironoxide-cli-windows-2019.asc release/windows-2019/ironoxide-cli-windows-2019
-  #     - name: Upload artifact for windows-2019
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/windows-2019/ironoxide-cli-windows-2019
-  #         asset_name: ironoxide-cli-windows-2019
-  #         asset_content_type: application/data
-  #     - name: Upload signature for windows-2019
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.release.outputs.upload_url }}
-  #         asset_path: release/windows-2019/ironoxide-cli-windows-2019.asc
-  #         asset_name: ironoxide-cli-windows-2019.asc
-  #         asset_content_type: application/pgp-signature
+
+  release:
+    runs-on: ubuntu-18.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Decrypt PGP key
+        uses: IronCoreLabs/ironhide-actions/decrypt@v1
+        with:
+          keys: ${{ secrets.IRONHIDE_KEYS }}
+          input: .github/signing-key.asc.iron
+      - name: Import PGP key
+        run: gpg --batch --import .github/signing-key.asc
+      - uses: actions/create-release@v1
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Version ${{ github.ref }}
+
+      - name: Download release artifacts from ubuntu-18.04
+        uses: actions/download-artifact@v1
+        with:
+          name: release-ubuntu-18.04
+          path: release/ubuntu-18.04
+      - name: Sign artifact for ubuntu-18.04
+        run: |
+          gpg --batch --detach-sign -a release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+          gpg --batch --verify release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+      - name: Upload artifact for ubuntu-18.04
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04
+          asset_name: ironoxide-cli-ubuntu-18.04
+          asset_content_type: application/data
+      - name: Upload signature for ubuntu-18.04
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/ubuntu-18.04/ironoxide-cli-ubuntu-18.04.asc
+          asset_name: ironoxide-cli-ubuntu-18.04.asc
+          asset_content_type: application/pgp-signature
+
+      - name: Download release artifacts from macos-10.15
+        uses: actions/download-artifact@v1
+        with:
+          name: release-macos-10.15
+          path: release/macos-10.15
+      - name: Sign artifact for macos-10.15
+        run: |
+          gpg --batch --detach-sign -a release/macos-10.15/ironoxide-cli-macos-10.15
+          gpg --batch --verify release/macos-10.15/ironoxide-cli-macos-10.15.asc release/macos-10.15/ironoxide-cli-macos-10.15
+      - name: Upload artifact for macos-10.15
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/macos-10.15/ironoxide-cli-macos-10.15
+          asset_name: ironoxide-cli-macos-10.15
+          asset_content_type: application/data
+      - name: Upload signature for macos-10.15
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/macos-10.15/ironoxide-cli-macos-10.15.asc
+          asset_name: ironoxide-cli-macos-10.15.asc
+          asset_content_type: application/pgp-signature
+
+      - name: Download release artifacts from windows-2019
+        uses: actions/download-artifact@v1
+        with:
+          name: release-windows-2019
+          path: release/windows-2019
+      - name: Sign artifact for windows-2019
+        run: |
+          gpg --batch --detach-sign -a release/windows-2019/ironoxide-cli-windows-2019
+          gpg --batch --verify release/windows-2019/ironoxide-cli-windows-2019.asc release/windows-2019/ironoxide-cli-windows-2019
+      - name: Upload artifact for windows-2019
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/windows-2019/ironoxide-cli-windows-2019
+          asset_name: ironoxide-cli-windows-2019
+          asset_content_type: application/data
+      - name: Upload signature for windows-2019
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: release/windows-2019/ironoxide-cli-windows-2019.asc
+          asset_name: ironoxide-cli-windows-2019.asc
+          asset_content_type: application/pgp-signature


### PR DESCRIPTION
Apparently Rust automatically adds a `.exe` to the end of its binary in Windows, so had to account for that in the build matrix.