### PR TITLE
Only run security audit on schedule

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,12 +1,8 @@
 name: Security Audit
 
-# Run daily and also when Cargo.toml changes
 on:
   schedule:
     - cron: "0 8 * * *" # 8AM UTC, 3PM MST
-  push:
-    paths:
-      - "**/Cargo.toml"
 
 jobs:
   security-audit:


### PR DESCRIPTION
We're inconsistent with this across repos, but this makes the triggers match our others. This will make this no longer run on PRs (making it look like CI is failing when it's just a previously-known dependency deprecation).